### PR TITLE
Fix (hack) to prevent a ClassNotFoundException

### DIFF
--- a/impl/src/main/java/pl/com/it_crowd/arquillian/mock_contexts/MockContextsManager.java
+++ b/impl/src/main/java/pl/com/it_crowd/arquillian/mock_contexts/MockContextsManager.java
@@ -30,8 +30,11 @@ public class MockContextsManager {
 
 // -------------------------- STATIC METHODS --------------------------
 
-    private static void setFacesContextCurrentInstance(FacesContext mock)
+    private static void setFacesContextCurrentInstance(Object objMock)
     {
+
+        FacesContext mock = (FacesContext) objMock;
+
         try {
             Method setCurrentInstance = FacesContext.class.getDeclaredMethod("setCurrentInstance", FacesContext.class);
             setCurrentInstance.setAccessible(true);


### PR DESCRIPTION
When Arquillian iterates through to figure out the observers, it
has to iterate through each method in the class. When it does this,
_IF_ FacesContext cannot be resolved, it will error out with a
ClassNotFoundException.

The circumstances of this error are the tests within a JSF project
that itself does not use JSF. For example, a test that initialises
and uses JPA within a test project
