### PR TITLE
MockFacesContextTest tests failing

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>2.0.0-alpha-1</version>
+            <version>1.0.0-beta-7</version>
             <scope>test</scope>
         </dependency>
 
@@ -95,6 +95,11 @@
             <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
             <version>2.0.0-alpha-2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.jboss.shrinkwrap.resolver</groupId>
+        	<artifactId>shrinkwrap-resolver-api-maven</artifactId>
+        	<version>1.0.0-beta-7</version>
         </dependency>
     </dependencies>
 </project>

--- a/test/src/test/java/pl/com/it_crowd/arquillian/mock_contexts/test/MockFacesContextTest.java
+++ b/test/src/test/java/pl/com/it_crowd/arquillian/mock_contexts/test/MockFacesContextTest.java
@@ -1,25 +1,28 @@
 package pl.com.it_crowd.arquillian.mock_contexts.test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.faces.context.FacesContext;
+
 import junit.framework.Assert;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.MavenImporter;
-import org.jboss.shrinkwrap.resolver.api.maven.filter.DependencyFilter;
+import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import pl.com.it_crowd.arquillian.mock_contexts.FacesContextRequired;
 import pl.com.it_crowd.arquillian.mock_contexts.MockFacesContextProducer;
-
-import javax.faces.context.FacesContext;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(Arquillian.class)
 public class MockFacesContextTest {
@@ -36,13 +39,18 @@ public class MockFacesContextTest {
 // -------------------------- STATIC METHODS --------------------------
 
     @Deployment
-    public static Archive getArchive()
+    public static Archive<?> getArchive()
     {
-        return ShrinkWrap.create(MavenImporter.class, MockFacesContextTest.class.getSimpleName() + ".war")
-            .loadEffectivePom("pom.xml")
-            .importAnyDependencies(new DependencyFilter("org.mockito:mockito-all"))
-            .as(WebArchive.class)
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        final MavenDependencyResolver resolver =
+                DependencyResolvers.use(MavenDependencyResolver.class)
+                .loadMetadataFromPom("pom.xml")
+                .goOffline();
+
+        Archive<?> archive = ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsLibraries(resolver.artifact("org.mockito:mockito-all").resolveAsFiles());
+
+        return archive;
     }
 
 // -------------------------- OTHER METHODS --------------------------


### PR DESCRIPTION
Hi,

I have built the packages and it seems to work fine (I am only using the ViewScopeRequired annotation just now).

However, the test package fails with the following:

---
##  T E S T S

Running pl.com.it_crowd.arquillian.mock_contexts.test.SampleTest
Dec 12, 2012 4:25:40 PM org.xnio.Xnio <clinit>
INFO: XNIO Version 3.0.3.GA
Dec 12, 2012 4:25:40 PM org.xnio.nio.NioXnio <clinit>
INFO: XNIO NIO Implementation Version 3.0.3.GA
Dec 12, 2012 4:25:40 PM org.jboss.remoting3.EndpointImpl <clinit>
INFO: JBoss Remoting version 3.2.2.GA
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.484 sec
Running pl.com.it_crowd.arquillian.mock_contexts.test.MockFacesContextTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Tests run: 3, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 2.975 sec <<< FAILURE!
Running pl.com.it_crowd.arquillian.mock_contexts.test.EjbArchiveTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.917 sec
Running pl.com.it_crowd.arquillian.mock_contexts.test.EnterpriseArchiveTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.556 sec

Results :

Tests in error: 
  facesContextNr1Availabile1(pl.com.it_crowd.arquillian.mock_contexts.test.MockFacesContextTest): org/jboss/shrinkwrap/resolver/api/maven/MavenResolutionFilter
  facesContextAvailabile2(pl.com.it_crowd.arquillian.mock_contexts.test.MockFacesContextTest): org/jboss/shrinkwrap/resolver/api/maven/MavenResolutionFilter
  facesContextNotAvailable(pl.com.it_crowd.arquillian.mock_contexts.test.MockFacesContextTest): org/jboss/shrinkwrap/resolver/api/maven/MavenResolutionFilter

Tests run: 9, Failures: 0, Errors: 3, Skipped: 0

Best Wishes,

Shri
